### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "overpass",
+  "version": "2.1.0",
+  "homepage": "http://overpassfont.org/",
+  "authors": [
+    "Delve Fonts",
+    "Red Hat"
+  ],
+  "description": "Overpass — an open source web font family",
+  "main": "Webfonts/recommended.css",
+  "keywords": [
+    "font",
+    "overpath"
+  ],
+  "license": "SIL"
+}


### PR DESCRIPTION
This adds a bower.json file so that the overpass fonts can be installed via `bower install overpass` (well, after merging this and running `bower register overpass https://github.com/RedHatBrand/overpass`).

Not quite sure if the authors field fits, or even the version, will change if asked to.. :)

(Also, please note that you need to `git tag 2.1.0` for it to work.)