### PR TITLE
Revert licensing to OFL only; add Reserved Font Name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,10 @@
 ## License
 
-Copyright 2015 Red Hat, Inc.,
-This Font Software is dual licensed and available under the SIL Open Font License, Version 1.1. and also the LGPL 2.1 
+Copyright 2015 Red Hat, Inc., with Reserved Font Name Overpass.
+This Font Software is licensed under the SIL Open Font
+License, Version 1.1.
 
-The Open Font license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
-
-The GNU LGPL can be found at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ For more information, please visit  [overpassfont.org](http://www.overpassfont.o
 
 ## License
 
-Copyright 2016 Red Hat, Inc.,
+Copyright 2016 Red Hat, Inc., with Reserved Font Name Overpass.
 
-This Font Software is dual licensed under the SIL Open Font License and the GNU Lesser General Public License,
-LGPL 2.1 : http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-OFL  1.1  : http://scripts.sil.org/OFL
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+See the file LICENSE.md or http://scripts.sil.org/OFL
 


### PR DESCRIPTION
Overpass was intended to be licensed under the SIL OFL 1.1. I separately opened #28 about the addition of LGPL 2.1. Unless there is a specific reason why LGPL 2.1 needs to be an available license choice, we should revert to just OFL. It would be difficult to determine how LGPL 2.1 maps to a font. 

I also added the designation of Overpass as a "Reserved Font Name", an OFL concept. I can't remember whether we specifically chose not to make use of that feature when Overpass was originally placed under OFL. 