### PR TITLE
Fix reference to regular italic in web font CSS

### DIFF
--- a/webfonts/overpass-webfont/overpass.css
+++ b/webfonts/overpass-webfont/overpass.css
@@ -82,11 +82,11 @@
 
 @font-face {
   font-family: 'overpass';
-  src: url('overpass-regular-italic.eot');
-  src: url('overpass-regular-italic.eot?#iefix') format('embedded-opentype'),
-       url('overpass-regular-italic.woff2') format('woff2'),
-       url('overpass-regular-italic.woff') format('woff'),
-       url('overpass-regular-italic.ttf')  format('truetype');
+  src: url('overpass-italic.eot');
+  src: url('overpass-italic.eot?#iefix') format('embedded-opentype'),
+       url('overpass-italic.woff2') format('woff2'),
+       url('overpass-italic.woff') format('woff'),
+       url('overpass-italic.ttf')  format('truetype');
        font-weight: 500;
        font-style: italic;
 }


### PR DESCRIPTION
The web font CSS was referring to font files with the name `overpass-regular-italic` but those doesn't exist. I assume it's supposed to point to the `overpass-italic` files and updated the CSS to reflect. Hope that's right!