### PR TITLE
Fix bower.json version and license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "overpass",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "homepage": "http://overpassfont.org/",
   "authors": [
     "Delve Fonts",
@@ -12,5 +12,5 @@
     "font",
     "overpath"
   ],
-  "license": "SIL"
+  "license": "(LGPL-2.1 AND OFL-1.1)"
 }


### PR DESCRIPTION
This pull request updates the `bower.json` file's:

* `version` to the latest released version
* `license` to reflect proper [SPDX](https://spdx.org/licenses/) license string per [README](https://github.com/RedHatBrand/Overpass#license)