### PR TITLE
Add a package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "overpass",
+  "version": "3.0.2",
+  "description": "Overpass — an open source web font family",
+  "author": "Red Hat",
+  "contributors": [
+    "Delve Fonts"
+  ],
+  "keywords": [
+    "font",
+    "overpass"
+  ],
+  "license": "(LGPL-2.1 AND OFL-1.1)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RedHatBrand/Overpass.git"
+  },
+  "bugs": {
+    "url": "https://github.com/RedHatBrand/Overpass/issues"
+  },
+  "homepage": "http://overpassfont.org/"
+}


### PR DESCRIPTION
This pull request adds a nodejs/npm `package.json` file.

We have found bower to be increasingly unreliable and would like to move all our `bower.json` dependencies to a `package.json` file so we can use either [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) to manage dependencies.

Note that you will also need to [publish this package](https://docs.npmjs.com/getting-started/publishing-npm-packages) after accepting this merge request.