### PR TITLE
Typo in bower.json keywords

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "main": "Webfonts/overpass.css",
   "keywords": [
     "font",
-    "overpath"
+    "overpass"
   ],
   "license": "SIL"
 }


### PR DESCRIPTION
Keyword `overpath` used instead of `overpass`.