### PR TITLE
Disable "Use Typo Metrics"

### DIFF
--- a/source/overpass-italic.glyphs
+++ b/source/overpass-italic.glyphs
@@ -171206,7 +171206,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 200;
@@ -171278,7 +171278,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 250;
@@ -171351,7 +171351,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 300;
@@ -171423,7 +171423,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 400;
@@ -171495,7 +171495,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 500;
@@ -171567,7 +171567,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 600;
@@ -171641,7 +171641,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 700;
@@ -171713,7 +171713,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 800;

--- a/source/overpass-mono.glyphs
+++ b/source/overpass-mono.glyphs
@@ -121154,7 +121154,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 300;
@@ -121224,7 +121224,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 400;
@@ -121294,7 +121294,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 500;
@@ -121367,7 +121367,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 600;

--- a/source/overpass.glyphs
+++ b/source/overpass.glyphs
@@ -133492,7 +133492,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 200;
@@ -133562,7 +133562,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 250;
@@ -133633,7 +133633,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 300;
@@ -133703,7 +133703,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 400;
@@ -133773,7 +133773,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 500;
@@ -133845,7 +133845,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 600;
@@ -133918,7 +133918,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 700;
@@ -133988,7 +133988,7 @@ value = 378;
 },
 {
 name = "Use Typo Metrics";
-value = 1;
+value = 0;
 }
 );
 interpolationWeight = 850;


### PR DESCRIPTION
Fixes #56 

This fixes the line height issues that are visible on Firefox on all platforms and other browsers on Windows. It's possible that this will change rendering in some places where it isn't desirable, but it fixes it and allows centering in some pretty common use-cases like buttons on redhat.com:


| Firefox | Chrome |
|-|-|
| <img width="301" alt="image 2018-08-19 at 6 34 09 pm" src="https://user-images.githubusercontent.com/8588/44316073-77a26a00-a3de-11e8-9c69-b60c8cbdbe59.png"> | <img width="297" alt="image 2018-08-19 at 6 34 22 pm" src="https://user-images.githubusercontent.com/8588/44316081-7ffaa500-a3de-11e8-9984-be2fe697f032.png"> |

Note that the fonts will need to be regenerated if this is applied, I only updated the sources and there are no generation instructions that I could find.